### PR TITLE
Update wmII.py

### DIFF
--- a/wmII.py
+++ b/wmII.py
@@ -112,15 +112,18 @@ class WMII(weewx.drivers.AbstractDevice):
 
     def genLoopPackets(self):
         while True:
-            packet = {"dateTime": int(time.time() + 0.5), "usUnits": weewx.US}
-            readings = self.station.get_readings_with_retry(
-                self.max_tries, self.retry_wait
-            )
-            data = self.station.parse_readings(readings)
-            packet.update(data)
-            self._augment_packet(packet)
-            yield packet
-            time.sleep(self.loop_interval)
+            try:
+                packet = {"dateTime": int(time.time() + 0.5), "usUnits": weewx.US}
+                readings = self.station.get_readings_with_retry(
+                    self.max_tries, self.retry_wait
+                )
+                data = self.station.parse_readings(readings)
+                packet.update(data)
+                self._augment_packet(packet)
+                yield packet
+                time.sleep(self.loop_interval)
+            except:
+                pass
 
     def _augment_packet(self, packet):
         packet["rain"] = weewx.wxformulas.calculate_rain(


### PR DESCRIPTION
Changed the function genLoopPackets() by adding try..except condition to catch errors. Instances where no (valid) response was received from the WM2 the function get_readings() caused an unexpected exit which crashed weewx.